### PR TITLE
When initing graphs get data of all sensors, instead of only enabled …

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -91,7 +91,7 @@ var getValues = function (cb) {
 
     async.series([
         function (done) {
-            getEnabledSensors(function (err, devices) {
+            getSensorsFromDb(function (err, devices) {
                 if (err) return done(err);
                 devices.forEach(function (device) {
                     var newDevice = {


### PR DESCRIPTION
…sensors.